### PR TITLE
Ignore "-UNKNOWN" version suffix when checking compatibility

### DIFF
--- a/Scripts/SL-Helpers.lua
+++ b/Scripts/SL-Helpers.lua
@@ -44,6 +44,9 @@ StepManiaVersionIsSupported = function()
 
 	-- remove the git hash if one is present in the version string
 	version = version:gsub("-git-.+", "")
+	
+	-- flatpak version (and maybe some other builds) has an "-UNKNOWN" suffix, remove it too
+        version = version:gsub("-UNKNOWN", "")
 
 	-- split the remaining version string on periods; store each segment in a temp table
 	local t = {}


### PR DESCRIPTION
Flatpak (and maybe some other) builds have `ProductVersion()` reporting as `5.1.0-UNKNOWN`. I'm pretty sure this is some build misconfiguration on the repo maintainers side, but apart from that the theme seems to work nicely with that version so I guess it's alright to allow this suffix just like `-git-.+`.